### PR TITLE
Fix deprecated usage of PropType via main React package

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "uglify-js": "^2.7.0"
   },
   "dependencies": {
+    "prop-types": "^15.5.8",
     "react": "^15.2.1",
     "react-dom": "^15.2.1"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lyef-switch-button",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A switch button (on/off) React component.",
   "main": "dist/Main.js",
   "scripts": {

--- a/src/Label.js
+++ b/src/Label.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const Label = ({ name, id }) => (
     <label className="label" htmlFor={id}>{name}</label>

--- a/src/Main.js
+++ b/src/Main.js
@@ -1,6 +1,7 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import Label from './Label';
 import Toggle from './Toggle';
+import PropTypes from 'prop-types';
 
 const propTypes = {
     id: PropTypes.string.isRequired,

--- a/src/Toggle.js
+++ b/src/Toggle.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const Toggle = ({ id, isChecked, action }) => (
     <div className="toggle-container">


### PR DESCRIPTION
Already bumped the package version with `npm version patch`.
Fixes #3.